### PR TITLE
added enclosure.BinaryAttachment - binary attachments that didn't com…

### DIFF
--- a/mailthon/api.py
+++ b/mailthon/api.py
@@ -10,7 +10,7 @@
 """
 
 
-from mailthon.enclosure import HTML, Attachment
+from mailthon.enclosure import HTML, Attachment, BinaryAttachment
 from mailthon.envelope import Envelope
 from mailthon.postman import Postman
 from mailthon.middleware import TLS, Auth
@@ -19,7 +19,7 @@ import mailthon.headers as headers
 
 def email(sender=None, receivers=(), cc=(), bcc=(),
           subject=None, content=None, encoding='utf8',
-          attachments=()):
+          attachments=(), binaries=()):
     """
     Creates an Envelope object with a HTML *content*.
 
@@ -28,8 +28,10 @@ def email(sender=None, receivers=(), cc=(), bcc=(),
     :param attachments: List of filenames to
         attach to the email.
     """
-    html = [HTML(content, encoding)]
-    files = [Attachment(k) for k in attachments]
+    enclosure=[]
+    enclosure.append(HTML(content, encoding))
+    enclosure.extend(tuple(Attachment(k) for k in attachments))
+    enclosure.extend(tuple(BinaryAttachment(k, t, f) for k, t, f in binaries))
     return Envelope(
         headers=[
             headers.subject(subject),
@@ -40,7 +42,7 @@ def email(sender=None, receivers=(), cc=(), bcc=(),
             headers.date(),
             headers.message_id(),
         ],
-        enclosure=(html + files),
+        enclosure=enclosure,
     )
 
 

--- a/mailthon/enclosure.py
+++ b/mailthon/enclosure.py
@@ -144,3 +144,20 @@ class Attachment(Binary):
         """
         with open(self.path, 'rb') as handle:
             return handle.read()
+
+class BinaryAttachment(Binary):
+    """
+    Binary subclass for easier binary attachments (not from files).
+
+    :param headers: Optional headers.
+    """
+
+    def __init__(self, content, mimetype, filename, encoding=None,
+                 encoder=encode_base64, headers=()):
+        self.content = content
+        self.mimetype = mimetype
+        self.encoding = encoding
+        self.encoder = encoder
+        heads = dict([content_disposition('attachment', filename)])
+        heads.update(headers)
+        self.headers = Headers(heads)


### PR DESCRIPTION
I hope I didn't overlook something, but I didn't see a way to attach stuff generated in memory (e.g. image, pdf, etc.).

1. added enclosure.BinaryAttachment, binary attachments that didn't come from files
2. modified api.email() to support BinaryAttachment (binaries=() parameter)

I didn't know what to do about encoding, so I left it defaulting to None like in the base class.  Is there a better choice?

I hope others find this helpful.  Thank you for your work!
