### PR TITLE
Unicode headers

### DIFF
--- a/mailthon/headers.py
+++ b/mailthon/headers.py
@@ -11,10 +11,10 @@
 """
 
 from email.utils import quote, formatdate, make_msgid, getaddresses
-from .helpers import format_addresses, encode_address
+from .helpers import format_addresses, UnicodeDict
 
 
-class Headers(dict):
+class Headers(UnicodeDict):
     """
     RFC 2822 compliant subclass of a dictionary. The
     semantics of the dictionary is different from
@@ -47,7 +47,7 @@ class Headers(dict):
         for item in to_fetch:
             if item in self:
                 _, addr = getaddresses([self[item]])[0]
-                return encode_address(addr)
+                return addr
 
     @property
     def receivers(self):

--- a/mailthon/headers.py
+++ b/mailthon/headers.py
@@ -11,7 +11,7 @@
 """
 
 from email.utils import quote, formatdate, make_msgid, getaddresses
-from .helpers import format_addresses
+from .helpers import format_addresses, encode_address
 
 
 class Headers(dict):
@@ -46,7 +46,8 @@ class Headers(dict):
         )
         for item in to_fetch:
             if item in self:
-                return self[item]
+                _, addr = getaddresses([self[item]])[0]
+                return encode_address(addr)
 
     @property
     def receivers(self):

--- a/mailthon/helpers.py
+++ b/mailthon/helpers.py
@@ -54,16 +54,16 @@ def encode_address(addr, encoding='utf-8'):
     if isinstance(addr, bytes_type):
         return addr
     try:
-        addr = addr.encode(encoding)
+        addr = addr.encode('ascii')
     except UnicodeEncodeError:
         if '@' in addr:
             localpart, domain = addr.split('@', 1)
-            addr = '@'.join([
+            addr = b'@'.join([
                 localpart.encode(encoding),
-                domain.decode('idna').encode('ascii'),
+                domain.encode('idna'),
             ])
         else:
-            raise
+            addr = addr.encode(encoding)
     return addr
 
 

--- a/mailthon/helpers.py
+++ b/mailthon/helpers.py
@@ -68,7 +68,7 @@ def encode_address(addr, encoding='utf-8'):
 
 
 class UnicodeDict(dict):
-    def __init__(self, values, encoding='utf-8'):
+    def __init__(self, values=(), encoding='utf-8'):
         self.encoding = encoding
         self.update(values)
 

--- a/mailthon/postman.py
+++ b/mailthon/postman.py
@@ -11,6 +11,7 @@
 from contextlib import contextmanager
 from smtplib import SMTP
 from .response import SendmailResponse
+from .helpers import encode_address
 
 
 class Postman(object):
@@ -72,8 +73,8 @@ class Postman(object):
         not close the connection.
         """
         rejected = conn.sendmail(
-            envelope.mail_from,
-            envelope.receivers,
+            encode_address(envelope.mail_from),
+            [encode_address(k) for k in envelope.receivers],
             envelope.string(),
         )
         return self.response_cls(conn.noop(), rejected)

--- a/tests/test_enclosure.py
+++ b/tests/test_enclosure.py
@@ -1,14 +1,8 @@
 # coding=utf8
-from sys import version_info
 from pytest import fixture
 from mailthon.enclosure import PlainText, HTML, Binary, Attachment
 from .mimetest import mimetest
-
-
-if version_info[0] == 3:
-    unicode = str
-else:
-    unicode = lambda k: k.decode('utf8')
+from .utils import unicode
 
 
 fixture = fixture(scope='class')

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -32,7 +32,7 @@ class TestEnvelope:
         assert mime['Subject'] == 'subject'
 
     def test_attrs(self, envelope):
-        assert envelope.sender == b'me@mail.com'
+        assert envelope.sender == 'me@mail.com'
         assert envelope.receivers == ['him@mail.com', 'them@mail.com']
 
     def test_mail_from_not_specified(self, envelope):

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -32,9 +32,8 @@ class TestEnvelope:
         assert mime['Subject'] == 'subject'
 
     def test_attrs(self, envelope):
-        assert envelope.sender == 'Me <me@mail.com>'
+        assert envelope.sender == b'me@mail.com'
         assert envelope.receivers == ['him@mail.com', 'them@mail.com']
-        assert envelope.sender == 'Me <me@mail.com>'
 
     def test_mail_from_not_specified(self, envelope):
         assert envelope.mail_from == envelope.sender

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -19,7 +19,7 @@ class TestNotResentHeaders:
         assert headers['To'] == 'to@mail.com'
 
     def test_sender(self, headers):
-        assert headers.sender == 'sender@mail.com'
+        assert headers.sender == b'sender@mail.com'
 
     def test_receivers(self, headers):
         assert set(headers.receivers) == set([
@@ -58,11 +58,11 @@ class TestResentHeaders(TestNotResentHeaders):
         return head
 
     def test_sender(self, headers):
-        assert headers.sender == 'rfrom@mail.com'
+        assert headers.sender == b'rfrom@mail.com'
 
     def test_prefers_resent_sender(self, headers):
         headers['Resent-Sender'] = 'rsender@mail.com'
-        assert headers.sender == 'rsender@mail.com'
+        assert headers.sender == b'rsender@mail.com'
 
     def test_resent_sender_without_senders(self, headers):
         del headers['Resent-From']

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -19,7 +19,7 @@ class TestNotResentHeaders:
         assert headers['To'] == 'to@mail.com'
 
     def test_sender(self, headers):
-        assert headers.sender == b'sender@mail.com'
+        assert headers.sender == 'sender@mail.com'
 
     def test_receivers(self, headers):
         assert set(headers.receivers) == set([
@@ -58,11 +58,11 @@ class TestResentHeaders(TestNotResentHeaders):
         return head
 
     def test_sender(self, headers):
-        assert headers.sender == b'rfrom@mail.com'
+        assert headers.sender == 'rfrom@mail.com'
 
     def test_prefers_resent_sender(self, headers):
         headers['Resent-Sender'] = 'rsender@mail.com'
-        assert headers.sender == b'rsender@mail.com'
+        assert headers.sender == 'rsender@mail.com'
 
     def test_resent_sender_without_senders(self, headers):
         del headers['Resent-From']

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,6 @@
 # coding=utf8
 import pytest
-from mailthon.helpers import guess, format_addresses, encode_address
+from mailthon.helpers import guess, format_addresses, encode_address, UnicodeDict
 
 
 def test_guess_recognised():
@@ -25,3 +25,36 @@ def test_encode_address():
     assert encode_address(u'mail@mail.com') == b'mail@mail.com'
     assert encode_address(u'mail@måil.com') == b'mail@xn--mil-ula.com'
     assert encode_address(u'måil@måil.com') == b'm\xc3\xa5il@xn--mil-ula.com'
+
+
+class TestUnicodeDict:
+    @pytest.fixture
+    def mapping(self):
+        return UnicodeDict({'Item': u'måil'})
+
+    def test_setitem(self):
+        u = UnicodeDict()
+        u['Item'] = b'm\xc3\xa5il'
+        assert u['Item'] == u'måil'
+
+    def test_getitem(self, mapping):
+        assert mapping['Item'] == u'måil'
+
+    def test_update(self, mapping):
+        mapping.update({
+            'Item-1': u'unicode-itém',
+            'Item-2': b'bytes-item',
+        })
+        assert mapping['Item-1'] == u'unicode-itém'
+        assert mapping['Item-2'] == u'bytes-item'
+
+    def test_get(self, mapping):
+        assert mapping.get('Something', default=None) is None
+        assert mapping.get('Item') == u'måil'
+
+    def test_get_bytes_encoding(self, mapping):
+        with pytest.raises(UnicodeEncodeError):
+            mapping.get_bytes('Item', encoding='ascii')
+
+    def test_get_bytes(self, mapping):
+        assert mapping.get_bytes('Item') == b'm\xc3\xa5il'

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -43,7 +43,7 @@ class TestUnicodeDict:
 
     def test_update(self, mapping):
         mapping.update({
-            'Item-1': u'unicode-itém',
+            'Item-1': uni('unicode-itém'),
             'Item-2': b'bytes-item',
         })
         assert mapping['Item-1'] == uni('unicode-itém')

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -31,27 +31,27 @@ def test_encode_address():
 class TestUnicodeDict:
     @pytest.fixture
     def mapping(self):
-        return UnicodeDict({'Item': u'måil'})
+        return UnicodeDict({'Item': uni('måil')})
 
     def test_setitem(self):
         u = UnicodeDict()
         u['Item'] = b'm\xc3\xa5il'
-        assert u['Item'] == u'måil'
+        assert u['Item'] == uni('måil')
 
     def test_getitem(self, mapping):
-        assert mapping['Item'] == u'måil'
+        assert mapping['Item'] == uni('måil')
 
     def test_update(self, mapping):
         mapping.update({
             'Item-1': u'unicode-itém',
             'Item-2': b'bytes-item',
         })
-        assert mapping['Item-1'] == u'unicode-itém'
-        assert mapping['Item-2'] == u'bytes-item'
+        assert mapping['Item-1'] == uni('unicode-itém')
+        assert mapping['Item-2'] == uni('bytes-item')
 
     def test_get(self, mapping):
         assert mapping.get('Something', default=None) is None
-        assert mapping.get('Item') == u'måil'
+        assert mapping.get('Item') == uni('måil')
 
     def test_get_bytes_encoding(self, mapping):
         with pytest.raises(UnicodeEncodeError):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,6 @@
+# coding=utf8
 import pytest
-from mailthon.helpers import guess, format_addresses
+from mailthon.helpers import guess, format_addresses, encode_address
 
 
 def test_guess_recognised():
@@ -18,3 +19,9 @@ def test_format_addresses():
         'Fender <fender@mail.com>',
     ])
     assert chunks == 'Sender <sender@mail.com>, Fender <fender@mail.com>'
+
+
+def test_encode_address():
+    assert encode_address(u'mail@mail.com') == b'mail@mail.com'
+    assert encode_address(u'mail@måil.com') == b'mail@xn--mil-ula.com'
+    assert encode_address(u'måil@måil.com') == b'm\xc3\xa5il@xn--mil-ula.com'

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,7 @@
 # coding=utf8
 import pytest
 from mailthon.helpers import guess, format_addresses, encode_address, UnicodeDict
+from .utils import unicode as uni
 
 
 def test_guess_recognised():
@@ -22,9 +23,9 @@ def test_format_addresses():
 
 
 def test_encode_address():
-    assert encode_address(u'mail@mail.com') == b'mail@mail.com'
-    assert encode_address(u'mail@måil.com') == b'mail@xn--mil-ula.com'
-    assert encode_address(u'måil@måil.com') == b'm\xc3\xa5il@xn--mil-ula.com'
+    assert encode_address(uni('mail@mail.com')) == b'mail@mail.com'
+    assert encode_address(uni('mail@måil.com')) == b'mail@xn--mil-ula.com'
+    assert encode_address(uni('måil@måil.com')) == b'm\xc3\xa5il@xn--mil-ula.com'
 
 
 class TestUnicodeDict:

--- a/tests/test_postman.py
+++ b/tests/test_postman.py
@@ -59,8 +59,8 @@ class TestPostman:
             r = postman.deliver(conn, envelope)
 
             calls = [
-                call.sendmail(envelope.mail_from,
-                              envelope.receivers,
+                call.sendmail(b'me@mail.com',
+                              [b'him@mail.com'],
                               envelope.string()),
                 call.noop(),
             ]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,8 @@
+from sys import version_info
+
+if version_info[0] == 3:
+    unicode = str
+    bytes_type = bytes
+else:
+    unicode = lambda k: k.decode('utf8')
+    bytes_type = str


### PR DESCRIPTION
The ``UnicodeDict`` allows headers to be specified in Unicode or byte-strings, and perform the conversion accordingly. Also, ``Headers.sender`` and ``receivers`` now return unicode addresses. The decision being that it is easier for subclasses to extend from and also makes it easier for the ``mail_from`` address to be specified, and also lets encoding to be done where it is required.

cc @rslinckx