### PR TITLE
Ability to set debuglevel for smtp transport

### DIFF
--- a/mailthon/postman.py
+++ b/mailthon/postman.py
@@ -60,7 +60,10 @@ class Postman(object):
         the server address, port, and options that have
         been passed to the constructor, in that order.
         """
+        debug_level = self.options.pop("debug_level", None)
         conn = self.transport(self.host, self.port, **self.options)
+        if debug_level is not None:
+            conn.set_debuglevel(debug_level)
         try:
             conn.ehlo()
             for item in self.middlewares:

--- a/tests/test_postman.py
+++ b/tests/test_postman.py
@@ -81,3 +81,10 @@ class TestPostman:
 
         with postman.connection() as conn:
             assert middleware.mock_calls == [call(conn)]
+
+    def test_debuglevel_was_used(self, smtp):
+        p = Postman(self.host, self.port, options=dict(debug_level=1))
+        p.transport = smtp
+        with p.connection() as conn:
+            pass
+        smtp.set_debuglevel.called_once_with(1)


### PR DESCRIPTION
It is very handy to have ability to view debug output from smtlib during prototyping or debugging (especially when working with some custom SMTP servers). 