### PR TITLE
change Sender field to From

### DIFF
--- a/mailthon/headers.py
+++ b/mailthon/headers.py
@@ -90,7 +90,7 @@ def sender(address):
     Generates a Sender header with a given *text*.
     *text* can be both a tuple or a string.
     """
-    yield 'Sender'
+    yield 'From'
     yield format_addresses([address])
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,7 +27,7 @@ class TestEmail:
 
     def test_headers(self, mime):
         assert mime['Subject'] == 'Something'
-        assert mime['Sender'] == 'Me <me@mail.com>'
+        assert mime['From'] == 'Me <me@mail.com>'
         assert mime['To'] == 'rcv@mail.com'
         assert mime['Cc'] == 'cc1@mail.com, cc2@mail.com'
         assert mime['Date']

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -29,7 +29,7 @@ class TestEnvelope:
     def test_mime_headers(self, envelope):
         mime = mimetest(envelope.mime())
 
-        assert mime['Sender'] == 'Me <me@mail.com>'
+        assert mime['From'] == 'Me <me@mail.com>'
         assert mime['To'] == 'him@mail.com, them@mail.com'
         assert mime['Subject'] == 'subject'
 

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -17,7 +17,7 @@ class TestNotResentHeaders:
         ])
 
     def test_getitem(self, headers):
-        assert headers['Sender'] == 'sender@mail.com'
+        assert headers['From'] == 'sender@mail.com'
         assert headers['To'] == 'to@mail.com'
 
     def test_sender(self, headers):

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -43,7 +43,6 @@ class TestNotResentHeaders:
         assert mime['Cc'] == 'cc1@mail.com, cc2@mail.com'
         assert mime['To'] == 'to@mail.com'
         assert mime['From'] == 'sender@mail.com'
-        assert mime['From'] == 'from@mail.com'
 
 
 class TestResentHeaders(TestNotResentHeaders):
@@ -99,7 +98,7 @@ def test_tuple_headers(function):
         ('From', 'sender@mail.com'),
         'Me <me@mail.com>',
     )
-    expected = 'Sender <sender@mail.com>, Me <me@mail.com>'
+    expected = 'From <sender@mail.com>, Me <me@mail.com>'
     assert value == expected
 
 

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -42,7 +42,7 @@ class TestNotResentHeaders:
         assert not mime['Bcc']
         assert mime['Cc'] == 'cc1@mail.com, cc2@mail.com'
         assert mime['To'] == 'to@mail.com'
-        assert mime['Sender'] == 'sender@mail.com'
+        assert mime['From'] == 'sender@mail.com'
         assert mime['From'] == 'from@mail.com'
 
 
@@ -96,7 +96,7 @@ class TestResentHeaders(TestNotResentHeaders):
 @pytest.mark.parametrize('function', [to, cc, bcc])
 def test_tuple_headers(function):
     _, value = function(
-        ('Sender', 'sender@mail.com'),
+        ('From', 'sender@mail.com'),
         'Me <me@mail.com>',
     )
     expected = 'Sender <sender@mail.com>, Me <me@mail.com>'

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -17,10 +17,10 @@ def test_guess_fallback():
 
 def test_format_addresses():
     chunks = format_addresses([
-        ('Sender', 'sender@mail.com'),
+        ('From', 'sender@mail.com'),
         'Fender <fender@mail.com>',
     ])
-    assert chunks == 'Sender <sender@mail.com>, Fender <fender@mail.com>'
+    assert chunks == 'From <sender@mail.com>, Fender <fender@mail.com>'
 
 
 def test_encode_address():


### PR DESCRIPTION
here we are.
I shouldn't mess with git without coffee :)

to summarize:
if I understand RFC2822, a mail have a from field (mandatory), and an optionnal sender field if there is multiple from addresses. (cf http://tools.ietf.org/html/rfc2822#section-3.6 )

with the email() api, From label is ommited, and make your mail tagged as spam, if not purely rejected.
mail clients also rely on this field (and not the Sender one) to display a name for the mail origin.