### PR TITLE
Fixes e-mail sending when using Python 3.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -156,7 +156,7 @@ Middlewares
 Helper Functions
 ----------------
 
-.. autofunction:: mailthon.helpers.encode_address
+.. autofunction:: mailthon.helpers.stringify_address
 
 .. autofunction:: mailthon.helpers.guess
 

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -89,4 +89,4 @@ makes passing in a special ``mail_from`` parameter to the
 :class:`~mailthon.envelope.Envelope`` class simpler; you do
 not need to worry about encoding since the :class:`~mailthon.postman.Postman`
 object encodes it for you behind the scenes, using the
-:func:`~mailthon.helpers.encode_address` function.
+:func:`~mailthon.helpers.stringify_address` function.

--- a/docs/indepth.rst
+++ b/docs/indepth.rst
@@ -332,7 +332,7 @@ first occurence of the '@' symbol.
 Putting it all together we have something like
 the following function::
 
-    def encode_address(addr):
+    def stringify_address(addr):
         localpart, domain = addr.split('@', 1)
         return b'@'.join([
             localpart.encode('utf8'),
@@ -340,15 +340,15 @@ the following function::
         ])
 
 But Mailthon already has a more robust implementation
-available in the form of the :func:`~mailthon.helpers.encode_address`
+available in the form of the :func:`~mailthon.helpers.stringify_address`
 function, and is automatically used by the :class:`~mailthon.postman.Postman`
 class when sending envelopes. Via the :meth:`~smtplib.SMTP.sendmail`
 method. Essentially, the following::
 
     def send(smtp, envelope):
         smtp.sendmail(
-            encode_address(envelope.sender),
-            [encode_address(k) for k in envelope.receivers],
+            stringify_address(envelope.sender),
+            [stringify_address(k) for k in envelope.receivers],
             envelope.string(),
         )
 

--- a/mailthon/helpers.py
+++ b/mailthon/helpers.py
@@ -47,12 +47,15 @@ def format_addresses(addrs):
     )
 
 
-def encode_address(addr, encoding='utf-8'):
+def stringify_address(addr, encoding='utf-8'):
     """
     Given an email address *addr*, try to encode
     it with ASCII. If it's not possible, encode
     the *local-part* with the *encoding* and the
     *domain* with IDNA.
+
+    The result is a unicode string with the domain
+    encoded as idna.
     """
     if isinstance(addr, bytes_type):
         return addr
@@ -67,7 +70,7 @@ def encode_address(addr, encoding='utf-8'):
             ])
         else:
             addr = addr.encode(encoding)
-    return addr
+    return addr.decode('utf-8')
 
 
 class UnicodeDict(dict):

--- a/mailthon/postman.py
+++ b/mailthon/postman.py
@@ -11,7 +11,7 @@
 from contextlib import contextmanager
 from smtplib import SMTP
 from .response import SendmailResponse
-from .helpers import encode_address
+from .helpers import stringify_address
 
 
 class Postman(object):
@@ -76,8 +76,8 @@ class Postman(object):
         not close the connection.
         """
         rejected = conn.sendmail(
-            encode_address(envelope.mail_from),
-            [encode_address(k) for k in envelope.receivers],
+            stringify_address(envelope.mail_from),
+            [stringify_address(k) for k in envelope.receivers],
             envelope.string(),
         )
         return self.response_cls(conn.noop(), rejected)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     include_package_data=True,
     package_data={'mailthon': ['LICENSE', 'README.rst']},
     packages=['mailthon'],
-    tests_require=['pytest'],
+    tests_require=['mock', 'pytest', 'pytest-localserver'],
     cmdclass={'test': PyTest},
     platforms='any',
     zip_safe=False,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,27 @@
+# -*- coding: utf-8 -*-
 import pytest
 from mock import Mock, call
 from mailthon.api import email, postman
+from mailthon.postman import Postman
 from mailthon.middleware import TLS, Auth
 from .mimetest import mimetest
 from .utils import smtp, tls_started
+
+
+class TestRealSmtp:
+
+    def test_send_email_example(self, smtpserver):
+        p = Postman(*smtpserver.addr)
+
+        r = p.send(email(
+            content=u'<p>Hello 世界</p>',
+            subject='Hello world',
+            sender='John <john@jon.com>',
+            receivers=['doe@jon.com'],
+        ))
+
+        assert r.ok
+        assert len(smtpserver.outbox) == 1
 
 
 class TestEmail:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,6 +23,30 @@ class TestRealSmtp:
         assert r.ok
         assert len(smtpserver.outbox) == 1
 
+    def test_send_email_attachment(self, smtpserver):
+        p = Postman(*smtpserver.addr)
+
+        r = p.send(email(
+            sender='Me <me@mail.com>',
+            receivers=['rcv@mail.com'],
+            subject='Something',
+            content='<p>hi</p>',
+            attachments=['tests/assets/spacer.gif'],
+            cc=['cc1@mail.com', 'cc2@mail.com'],
+            bcc=['bcc1@mail.com', 'bcc2@mail.com'],
+            encoding='ascii',
+        ))
+
+        assert r.ok
+        assert len(smtpserver.outbox) == 1
+
+        message = smtpserver.outbox[0]
+        assert message['Content-Type'].startswith('multipart/mixed')
+        assert message['Subject'] == 'Something'
+        assert message['To'] == 'rcv@mail.com'
+        assert message['CC'] == 'cc1@mail.com, cc2@mail.com'
+        assert message['From'] == 'Me <me@mail.com>'
+
 
 class TestEmail:
     @pytest.fixture(scope='class')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,7 +14,7 @@ class TestRealSmtp:
         p = Postman(*smtpserver.addr)
 
         r = p.send(email(
-            content=u'<p>Hello 世界</p>',
+            content='<p>Hello 世界</p>',
             subject='Hello world',
             sender='John <john@jon.com>',
             receivers=['doe@jon.com'],

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,7 +1,7 @@
 # coding=utf8
 import pytest
 from mailthon.helpers import (guess, format_addresses,
-                              encode_address, UnicodeDict)
+                              stringify_address, UnicodeDict)
 from .utils import unicode as uni
 
 
@@ -23,10 +23,10 @@ def test_format_addresses():
     assert chunks == 'From <sender@mail.com>, Fender <fender@mail.com>'
 
 
-def test_encode_address():
-    assert encode_address(uni('mail@mail.com')) == b'mail@mail.com'
-    assert encode_address(uni('mail@måil.com')) == b'mail@xn--mil-ula.com'
-    assert encode_address(uni('måil@måil.com')) == b'm\xc3\xa5il@xn--mil-ula.com'
+def test_stringify_address():
+    assert stringify_address(uni('mail@mail.com')) == u'mail@mail.com'
+    assert stringify_address(uni('mail@måil.com')) == u'mail@xn--mil-ula.com'
+    assert stringify_address(uni('måil@måil.com')) == u'måil@xn--mil-ula.com'
 
 
 class TestUnicodeDict:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -24,9 +24,9 @@ def test_format_addresses():
 
 
 def test_stringify_address():
-    assert stringify_address(uni('mail@mail.com')) == u'mail@mail.com'
-    assert stringify_address(uni('mail@måil.com')) == u'mail@xn--mil-ula.com'
-    assert stringify_address(uni('måil@måil.com')) == u'måil@xn--mil-ula.com'
+    assert stringify_address(uni('mail@mail.com')) == uni('mail@mail.com')
+    assert stringify_address(uni('mail@måil.com')) == uni('mail@xn--mil-ula.com')
+    assert stringify_address(uni('måil@måil.com')) == uni('måil@xn--mil-ula.com')
 
 
 class TestUnicodeDict:

--- a/tests/test_postman.py
+++ b/tests/test_postman.py
@@ -60,8 +60,8 @@ class TestPostman:
         with postman.connection() as conn:
             postman.deliver(conn, envelope)
             sendmail = call.sendmail(
-                envelope.sender.encode(),
-                [u.encode() for u in envelope.receivers],
+                envelope.sender,
+                envelope.receivers,
                 envelope.string(),
             )
             ehlo = call.ehlo()


### PR DESCRIPTION
See #18.

I added pytest-localserver, which offers an actual smtp server to test against. I refrained from using it everywhere, because I don't understand all the test cases well enough. I think it would be a good idea though, testing against an actual server always beats testing against a mock.

See the test I added for an example.

Please let me know if there's anything unclear or if there are any things I should be doing differently.