### PR TITLE
Encode headers back from unicode to str in prepare

### DIFF
--- a/mailthon/headers.py
+++ b/mailthon/headers.py
@@ -74,7 +74,7 @@ class Headers(UnicodeDict):
             if key == 'Bcc' or key == 'Resent-Bcc':
                 continue
             del mime[key]
-            mime[key] = self[key]
+            mime[key] = self[key].encode('utf-8')
 
 
 def subject(text):


### PR DESCRIPTION
Header values should be encoded back to `str` before generating string from mime object. In first place it affects attachments with non-ascii symbols in their names.
Before fix:
```python
In [2]: a = Attachment(u"/Users/psih/Documents/канада_шмот.rtf")

In [3]: a.headers
Out[3]: {'Content-Disposition': u'attachment; filename="\u043a\u0430\u043d\u0430\u0434\u0430_\u0448\u043c\u043e\u0442.rtf"'}

In [4]: a.mime().items()
Out[4]:
[('Content-Type', 'application/rtf'),
 ('MIME-Version', '1.0'),
 ('Content-Transfer-Encoding', 'base64'),
 ('Content-Disposition',
  u'attachment; filename="\u043a\u0430\u043d\u0430\u0434\u0430_\u0448\u043c\u043e\u0442.rtf"')]

In [5]: a.mime().as_string()
Out[5]: 'Content-Type: application/rtf\nMIME-Version: 1.0\nContent-Transfer-Encoding: base64\nContent-Disposition: =?utf-8?b?YXR0YWNobWVudDsgZmlsZW5hbWU9ItC60LDQvdCw0LQ=?=\n =?utf-8?b?0LBf0YjQvNC+0YIucnRmIg==?=\n\ne1xydGYxXGFuc2lcYW5zaWNwZzEyNTFcY29jb2FydGYxMzQ4XGNvY29hc3VicnRmMTcwCntcZm9u\ndHRibFxmMFxmc3dpc3NcZmNoYXJz.....'
```
-- take a loot at `Content-Disposition` header

After fix:
```python
In [2]: a = Attachment(u"/Users/psih/Documents/канада_шмот.rtf")

In [3]: a.headers
Out[3]: {'Content-Disposition': u'attachment; filename="\u043a\u0430\u043d\u0430\u0434\u0430_\u0448\u043c\u043e\u0442.rtf"'}

In [4]: a.mime().items()
Out[4]:
[('Content-Type', 'application/rtf'),
 ('MIME-Version', '1.0'),
 ('Content-Transfer-Encoding', 'base64'),
 ('Content-Disposition',
  'attachment; filename="\xd0\xba\xd0\xb0\xd0\xbd\xd0\xb0\xd0\xb4\xd0\xb0_\xd1\x88\xd0\xbc\xd0\xbe\xd1\x82.rtf"')]

In [5]: a.mime().as_string()
Out[5]: 'Content-Type: application/rtf\nMIME-Version: 1.0\nContent-Transfer-Encoding: base64\nContent-Disposition: attachment; filename="\xd0\xba\xd0\xb0\xd0\xbd\xd0\xb0\xd0\xb4\xd0\xb0_\xd1\x88\xd0\xbc\xd0\xbe\xd1\x82.rtf"\n\ne1xydGYxXGFuc2lcYW5zaWNwZzEyNTFcY29jb2FydGYxMzQ4XGNvY29hc3...'
```